### PR TITLE
change rel="shortcut icon" to rel="icon"

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="shortcut icon" href="%PUBLIC_URL%/icons/android-icon-48x48.png" />
+    <link rel="icon" href="%PUBLIC_URL%/icons/android-icon-48x48.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#FFFFFF" />
     <meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
According to MDN:
> Warning: The shortcut link type is often seen before icon, but this link type is non-conforming, ignored and web authors must not use it anymore.

[source](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types)